### PR TITLE
fix missing kernlab package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN R -e "install.packages('rstac')"
 RUN R -e "install.packages('sf')"
 RUN R -e "install.packages('sp')"
 RUN R -e "install.packages('randomForest')"
+RUN R -e "install.packages('kernlab')"
 
 COPY package*.json ./
 # Install with a clean slate


### PR DESCRIPTION
R Ausgabe:
```
Error in library(kernlab) : there is no package called ‘kernlab’
Calls: source -> withVisible -> eval -> eval -> library
Execution halted
```